### PR TITLE
Allow a host header to be configured and passed

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -54,6 +54,7 @@ function HealthApisTokenValidator:access(conf)
     ssl_verify = false,
     headers = {
       Authorization = ngx.req.get_headers()["Authorization"],
+      Host = self.conf.verification_host,
       apiKey = self.conf.api_key,
     },
   })

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -3,6 +3,7 @@ return {
   fields = {
     verification_url = {type = "string"},
     verification_timeout = {type = "number", default = 10000},
+    verification_host = {type = "string"}
     api_key = {type = "string"}
   }
 }


### PR DESCRIPTION
Needed to handle vets-api host checking