### PR TITLE
Bug/api 628 restore test patient kong plugin

### DIFF
--- a/src/handler.lua
+++ b/src/handler.lua
@@ -29,6 +29,7 @@ local OPERATIONAL_OUTCOME_TEMPLATE =
 local INVALID_TOKEN = "invalid token."
 local BAD_VALIDATE_ENDPOINT = "Validate endpoint not found."
 local VALIDATE_ERROR = "Error validating token."
+local ICN_MISSING = "Patient identifier not supplied."
 local TOKEN_MISMATCH = "Token not allowed access to this patient."
 local SCOPE_MISMATCH = "Token not granted requested scope."
 
@@ -48,15 +49,15 @@ function HealthApisTokenValidator:access(conf)
 
   local token = self:get_token_from_auth_string(ngx.req.get_headers()["Authorization"])
   local tokenIcn = nil
-  
+
   if (token == self.conf.static_token) then
-    tokenIcn = self.conf.static_icn    
-  else 
+    tokenIcn = self.conf.static_icn
+  else
     local responseJson = self:check_token()
-    
+
     tokenIcn = responseJson.data.attributes["va_identifiers"].icn
     responseScopes = responseJson.data.attributes.scp
-    
+
     self:check_scope(responseScopes)
   end
 
@@ -98,49 +99,32 @@ function HealthApisTokenValidator:check_token()
   if (verification_res_status < 200 or verification_res_status > 299) then
     return self:send_response(500, VALIDATE_ERROR)
   end
-  
+
   return cjson.decode(verification_res_body)
 
 end
 
 function HealthApisTokenValidator:check_icn(tokenIcn)
 
-  local requestIcn = ngx.req.get_uri_args()["patient"]
+  local requestIcn = self:get_request_icn()
 
   if (requestIcn == nil) then
-    i, j = find(ngx.var.uri, "/Patient/")
-    if (i ~= nil) then
-      local pathIcn = string.sub(ngx.var.uri, j+1, j+1+string.len(tokenIcn))
-      if (pathIcn ~= tokenIcn) then
-        ngx.log(ngx.INFO, "Path ICN does not match token")
-        return self:send_response(403, TOKEN_MISMATCH)
-      end
+    if (self:is_request_search()) then
+      return self:send_response(403, ICN_MISSING)
     end
-  else
-    if (requestIcn ~= tokenIcn) then
-      ngx.log(ngx.INFO, "Requested ICN does not match token")
-      return self:send_response(403, TOKEN_MISMATCH)
-    end
+  elseif (requestIcn ~= tokenIcn) then
+    ngx.log(ngx.INFO, "Requested ICN does not match token")
+    return self:send_response(403, TOKEN_MISMATCH)
   end
 
 end
 
 function HealthApisTokenValidator:check_scope(tokenScope)
 
-  local requestedResource = nil
-
-  if (ngx.req.get_uri_args()["patient"] == nil) then
-    local requestedResourceRead = string.match(ngx.var.uri, "/%a*/[%w%-]+$")
-    i, j = find(requestedResourceRead, "/%a*/")
-    if (i ~= nil) then
-      requestedResource = string.sub(requestedResourceRead, i+1, j-1)
-    end
-  else
-    requestedResource = string.match(ngx.var.uri, "%a*$")
-  end
-
+  local requestedResource = self:get_requested_resource_type()
   local requestScope = "patient/" .. requestedResource .. ".read"
 
+  ngx.log(ngx.ERR, "Requested scope: ", requestScope)
   if (self:check_for_array_entry(tokenScope, requestScope) ~= true) then
     ngx.log(ngx.INFO, "Requested resource scope not granted to token")
     return self:send_response(403, SCOPE_MISMATCH)
@@ -167,6 +151,70 @@ function HealthApisTokenValidator:get_token_from_auth_string(authString)
   else
     return "Bad Token"
   end
+
+end
+
+function HealthApisTokenValidator:is_request_read()
+  local requestedResourceRead = string.match(ngx.var.uri, "/%a*/[%w%-]+$")
+  return (requestedResourceRead ~= nil)
+end
+
+function HealthApisTokenValidator:is_request_search()
+  return (self:get_search_icn() ~= nil)
+end
+
+function HealthApisTokenValidator:get_request_icn()
+
+  if (self:is_request_read()) then
+    return self:get_read_icn()
+  else
+    return self:get_search_icn()
+  end
+
+end
+
+function HealthApisTokenValidator:get_read_icn()
+
+  i, j = find(ngx.var.uri, "/Patient/")
+  if (i ~= nil) then
+    local pathIcn = string.sub(ngx.var.uri, j+1)
+    return pathIcn
+  end
+
+end
+
+function HealthApisTokenValidator:get_search_icn()
+
+  local patientIcn = ngx.req.get_uri_args()["patient"];
+  local _idIcn = ngx.req.get_uri_args()["_id"]
+
+  if (patientIcn ~= nil) then
+    return patientIcn
+  elseif (_idIcn ~= nil) then
+    --_id is only a valid search for Patient
+    if (self:get_requested_resource_type() == "Patient") then
+      return _idIcn
+    end
+  else
+  end
+
+end
+
+function HealthApisTokenValidator:get_requested_resource_type()
+
+  local requestedResource = nil
+
+  if (self:is_request_read()) then
+    local requestedResourceRead = string.match(ngx.var.uri, "/%a*/[%w%-]+$")
+    i, j = find(requestedResourceRead, "/%a*/")
+    if (i ~= nil) then
+      requestedResource = string.sub(requestedResourceRead, i+1, j-1)
+    end
+  else
+    requestedResource = string.match(ngx.var.uri, "%a*$")
+  end
+
+  return requestedResource
 
 end
 

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -59,9 +59,9 @@ function HealthApisTokenValidator:access(conf)
     
     self:check_scope(responseScopes)
   end
-    
+
   self:check_icn(tokenIcn)
-    
+
 end
 
 function HealthApisTokenValidator:check_token()

--- a/src/handler.lua
+++ b/src/handler.lua
@@ -73,9 +73,9 @@ function HealthApisTokenValidator:check_token()
     method = "GET",
     ssl_verify = false,
     headers = {
-    Authorization = ngx.req.get_headers()["Authorization"],
-    Host = self.conf.verification_host,
-    apiKey = self.conf.api_key,
+      Authorization = ngx.req.get_headers()["Authorization"],
+      Host = self.conf.verification_host,
+      apiKey = self.conf.api_key,
     },
   })
 

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -4,6 +4,8 @@ return {
     verification_url = {type = "string"},
     verification_timeout = {type = "number", default = 10000},
     verification_host = {type = "string"},
+    static_token = {type = "string", default = ""},
+    static_icn = {type = "string", default = ""},
     api_key = {type = "string"}
   }
 }


### PR DESCRIPTION
JIRA Issue: https://vasdvp.atlassian.net/browse/API-628

Currently a static access token and static patient icn are used for certain testing and Pingdom monitoring.  The health-apis-token-validator plugin has been updated to include these values as optional parameters in schema.lua.

The plugin will check the supplied token against the configured static access token.  If matched, the token and scope validation steps are skipped.  ICN validation is still completed against the configured static-icn to ensure only test data can be viewed.

A "real" access token completes token, scope, and ICN validation normally.

**Before applying these changes to dev-api.va.gov (and higher environments) and MR must be completed.**